### PR TITLE
PyTorch Training Pipeline MacOS Fix

### DIFF
--- a/pareidolia-desktop/package-lock.json
+++ b/pareidolia-desktop/package-lock.json
@@ -568,6 +568,7 @@
       "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -1740,6 +1741,7 @@
       "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^3.0.1",
         "@inquirer/confirm": "^4.0.1",
@@ -2910,6 +2912,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2976,6 +2979,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3257,6 +3261,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4722,17 +4727,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/end-of-stream": {
@@ -8792,6 +8786,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9715,6 +9710,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9728,6 +9724,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9834,6 +9831,7 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/pareidolia-desktop/py/image_data_module.py
+++ b/pareidolia-desktop/py/image_data_module.py
@@ -106,6 +106,13 @@ class ImageDataModule(pl.LightningDataModule):
             transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
         ])
 
+        self.rep_transform = transforms.Compose([
+            transforms.Resize(256),
+            transforms.CenterCrop(img_size),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ])
+
     def load_images_from_json(self, labels_json):
         """Load images from a JSON mapping of label names to arrays of folder paths."""
 
@@ -184,6 +191,9 @@ class ImageDataModule(pl.LightningDataModule):
 
         generator = torch.Generator().manual_seed(self.seed)
         all_indices = torch.randperm(n_total, generator=generator).tolist()
+
+        print("All indices: ", all_indices)  # Print the first 10 shuffled indices for debugging
+
         train_indices = all_indices[:n_train]
         val_indices = all_indices[n_train:n_train + n_val]
         test_indices = all_indices[n_train + n_val:]
@@ -214,6 +224,9 @@ class ImageDataModule(pl.LightningDataModule):
             n_total = len(images)
             train_indices, val_indices, test_indices = self._get_split_indices(n_total)
             eval_base = NumpyImageDataset(images, labels, transform=self.eval_transform)
+
+            rep_base = NumpyImageDataset(images, labels, transform=self.rep_transform)
+            self.rep_ds = torch.utils.data.Subset(rep_base, test_indices)
 
             if stage in ("fit", None):
                 train_base = NumpyImageDataset(images, labels, transform=self.train_transform)
@@ -306,6 +319,16 @@ class ImageDataModule(pl.LightningDataModule):
     def predict_dataloader(self):
         return DataLoader(
             self.predict_ds,
+            batch_size=self.batch_size,
+            shuffle=False,
+            num_workers=self.num_workers,
+            pin_memory=torch.cuda.is_available(),
+            persistent_workers=self.num_workers > 0,
+        )
+    
+    def representative_dataloader(self):
+        return DataLoader(
+            self.rep_ds,
             batch_size=self.batch_size,
             shuffle=False,
             num_workers=self.num_workers,

--- a/pareidolia-desktop/py/pt_model.py
+++ b/pareidolia-desktop/py/pt_model.py
@@ -83,3 +83,70 @@ class RepVGGClassifier(pl.LightningModule):
 
     def configure_optimizers(self):
         return torch.optim.Adam(self.parameters(), lr=self.hparams.lr)
+# Cell 1: Model
+# class MobileNetV4Classifier(pl.LightningModule):
+#     """
+#     Author: Armando Vega
+#     Date Created: 13 April 2026
+    
+#     A PyTorch Lightning module utilizing MobileNetV4 as a backbone.
+#     Optimized for TFLite conversion and mobile deployment.
+#     """
+#     def __init__(self, model_name="mobilenetv4_conv_medium.e250_r384_in12k_ft_in1k", 
+#                  num_classes=10, lr=1e-3, hidden_dim=512):
+#         super().__init__()
+#         self.save_hyperparameters()
+
+#         # Load the backbone
+#         self.backbone = timm.create_model(
+#             model_name,
+#             pretrained=True,
+#             num_classes=0,       # Remove the original ImageNet head
+#             global_pool="avg",   # Use Global Average Pooling
+#         )
+
+#         # Dynamic feature detection to avoid "mat1 and mat2" shape errors
+#         # For mobilenetv4_conv_medium, this will be 1280
+#         n_features = self.backbone.num_features
+        
+#         self.head = nn.Sequential(
+#             nn.Dropout(0.3),
+#             nn.Linear(n_features, hidden_dim), 
+#             nn.ReLU(),
+#             nn.Dropout(0.2),
+#             nn.Linear(hidden_dim, num_classes),
+#         )
+
+#         # Metrics
+#         self.train_acc = Accuracy(task="multiclass", num_classes=num_classes)
+#         self.val_acc = Accuracy(task="multiclass", num_classes=num_classes)
+#         self.test_acc = Accuracy(task="multiclass", num_classes=num_classes)
+
+#     def forward(self, x):
+#         # MobileNetV4 expects [Batch, 3, 384, 384]
+#         features = self.backbone(x)
+#         return self.head(features)
+
+#     def training_step(self, batch, batch_idx):
+#         x, y = batch
+#         logits = self(x)
+#         loss = nn.functional.cross_entropy(logits, y)
+        
+#         self.train_acc(logits, y)
+#         self.log("train_loss", loss, on_step=False, on_epoch=True, prog_bar=True)
+#         self.log("train_acc", self.train_acc, on_step=False, on_epoch=True, prog_bar=True)
+#         return loss
+
+#     def validation_step(self, batch, batch_idx):
+#         x, y = batch
+#         logits = self(x)
+#         loss = nn.functional.cross_entropy(logits, y)
+        
+#         self.val_acc(logits, y)
+#         self.log("val_loss", loss, on_step=False, on_epoch=True, prog_bar=True)
+#         self.log("val_acc", self.val_acc, on_step=False, on_epoch=True, prog_bar=True)
+#         return loss
+
+#     def configure_optimizers(self):
+#         # Adam is a solid choice for MobileNet fine-tuning
+#         return torch.optim.Adam(self.parameters(), lr=self.hparams.lr)

--- a/pareidolia-desktop/py/pt_train_model.py
+++ b/pareidolia-desktop/py/pt_train_model.py
@@ -57,11 +57,13 @@ from epoch_history_printer import EpochHistoryPrinter
 from pathlib import Path
 import glob
 import subprocess
+import tempfile
 
 # Model constants
 IMG_HEIGHT = 224
 IMG_WIDTH = 224
 IMG_CHANNELS = 3
+REPRESENTATIVE_SAMPLE_COUNT = 128
 # NUM_CLASSES is now determined dynamically from the labels JSON at runtime
 LEARNING_RATE = 0.001
 CONVERTER_VENV_NAME = "converter-venv-macos-tf219"
@@ -248,6 +250,34 @@ def rep_test(loader):
             img = tf.expand_dims(img, axis=0)                         # add batch dim [1, 224, 224, 3]
             yield [img]
 
+def build_representative_samples(loader, max_samples=REPRESENTATIVE_SAMPLE_COUNT):
+    """
+    Materializes representative calibration samples as NHWC float32 arrays.
+    This keeps TF conversion in a clean subprocess and avoids TF/PyTorch
+    runtime lock contention inside one process on macOS.
+    """
+    mean = np.array([0.485, 0.456, 0.406], dtype=np.float32)
+    std = np.array([0.229, 0.224, 0.225], dtype=np.float32)
+    samples = []
+
+    for image_batch, _ in loader:
+        batch_size = image_batch.shape[0]
+        for i in range(batch_size):
+            img = image_batch[i].permute(1, 2, 0).cpu().numpy().astype(np.float32)
+            img = cv2.resize(img, (256, 256), interpolation=cv2.INTER_LINEAR)
+            offset = (256 - 224) // 2
+            img = img[offset:offset + 224, offset:offset + 224, :]
+            img = (img - mean) / std
+            samples.append(img)
+
+            if len(samples) >= max_samples:
+                return np.stack(samples, axis=0).astype(np.float32)
+
+    if not samples:
+        raise RuntimeError("Representative dataset is empty; cannot run TFLite quantization.")
+
+    return np.stack(samples, axis=0).astype(np.float32)
+
 def compute_mean_std_welford_fast_test(loader, image_size=256, crop_size=224):
     """Vectorized Welford — updates per image batch of pixels, not per pixel."""
     tf, _, _, _ = import_tensorflow_keras()
@@ -385,60 +415,64 @@ def convert_onnx_to_tf(onnx_model_path, tf_model_path, converter_python):
             'error': str(e)
         }
 
-
-def collect_generated_tflite(tf_model_path, onnx_model_path):
-    base_name = os.path.splitext(os.path.basename(onnx_model_path))[0]
-    preferred_files = [
-        os.path.join(tf_model_path, f"{base_name}_float32.tflite"), 
-        os.path.join(tf_model_path, f"{base_name}_float16.tflite"),
-        os.path.join(tf_model_path, f"{base_name}.tflite"),
-    ]
-    for candidate in preferred_files:
-        if os.path.exists(candidate):
-            return candidate
-
-    fallback = sorted(glob.glob(os.path.join(tf_model_path, "*.tflite")))
-    return fallback[0] if fallback else None
-
-
-def finalize_tflite_output(tf_model_path, model_folder, onnx_model_path):
+def tf_to_tflite(tf_model_path, tflite_model_path, representative_samples, converter_python):
+    representative_path = None
     try:
-        generated_tflite = collect_generated_tflite(tf_model_path, onnx_model_path)
-        if generated_tflite is None:
-            raise FileNotFoundError(f"No .tflite file generated in {tf_model_path}")
+        os.makedirs(os.path.dirname(tflite_model_path), exist_ok=True)
 
-        final_tflite_path = os.path.join(model_folder, "model.tflite")
-        shutil.copy2(generated_tflite, final_tflite_path)
-        print(f"Copied TFLite model to: {final_tflite_path}")
-        return {
-            'success': True,
-            'tflite_model': final_tflite_path
-        }
-    except Exception as e:
-        print(f"Error finalizing TFLite output: {str(e)}")
-        return {
-            'success': False,
-            'error': str(e)
-        }
+        if sys.platform == "darwin":
+            # macOS-only isolation to avoid TF/PyTorch runtime lock contention.
+            with tempfile.NamedTemporaryFile(
+                mode="wb",
+                suffix=".npy",
+                prefix="representative_",
+                dir=os.path.dirname(tflite_model_path),
+                delete=False,
+            ) as temp_file:
+                representative_path = temp_file.name
 
-def tf_to_tflite(tf_model_path, tflite_model_path, loader):
-    tf, _, _, _ = import_tensorflow_keras()
+            np.save(representative_path, representative_samples)
 
-    try:
-        converter = tf.lite.TFLiteConverter.from_saved_model(tf_model_path)
-        converter.optimizations = [tf.lite.Optimize.DEFAULT]
-        # converter.representative_dataset = representative_data_gen
-        converter.representative_dataset = lambda: rep_test(loader)
-        converter.target_spec.supported_ops = [
-            tf.lite.OpsSet.TFLITE_BUILTINS_INT8,
-            tf.lite.OpsSet.TFLITE_BUILTINS,
-        ]
-        converter.inference_input_type = tf.uint8
-        converter.inference_output_type = tf.float32
-        tflite_model = converter.convert()
+            worker_script = str(Path(__file__).resolve().with_name("tflite_convert_worker.py"))
+            env = os.environ.copy()
+            env.setdefault("TF_CPP_MIN_LOG_LEVEL", "1")
+            env.setdefault("TF_NUM_INTEROP_THREADS", "1")
+            env.setdefault("TF_NUM_INTRAOP_THREADS", "1")
+            env.setdefault("OMP_NUM_THREADS", "1")
 
-        with open(tflite_model_path, "wb") as f:
-            f.write(tflite_model)
+            run_logged_subprocess(
+                [
+                    converter_python,
+                    worker_script,
+                    "--saved-model",
+                    tf_model_path,
+                    "--output",
+                    tflite_model_path,
+                    "--rep-data",
+                    representative_path,
+                ],
+                env=env,
+            )
+        else:
+            tf, _, _, _ = import_tensorflow_keras()
+
+            def representative_dataset():
+                for sample in representative_samples:
+                    yield [np.expand_dims(sample.astype(np.float32), axis=0)]
+
+            converter = tf.lite.TFLiteConverter.from_saved_model(tf_model_path)
+            converter.optimizations = [tf.lite.Optimize.DEFAULT]
+            converter.representative_dataset = representative_dataset
+            converter.target_spec.supported_ops = [
+                tf.lite.OpsSet.TFLITE_BUILTINS_INT8,
+                tf.lite.OpsSet.TFLITE_BUILTINS,
+            ]
+            converter.inference_input_type = tf.uint8
+            converter.inference_output_type = tf.float32
+            tflite_model = converter.convert()
+
+            with open(tflite_model_path, "wb") as f:
+                f.write(tflite_model)
 
         print(f"TFLite model saved to: {tflite_model_path}")
         return {
@@ -451,6 +485,13 @@ def tf_to_tflite(tf_model_path, tflite_model_path, loader):
             'success': False,
             'error': str(e)
         }
+    finally:
+        if representative_path and os.path.exists(representative_path):
+            try:
+                os.remove(representative_path)
+            except OSError:
+                print(f"Could not delete temporary representative data file: {representative_path}")
+
 class RepVGGWithPreprocess(pl.LightningModule):
     def __init__(self, base_model):
         super().__init__()
@@ -504,7 +545,7 @@ if __name__ == "__main__":
     # Load and prepare images from the JSON label map
     model = RepVGGClassifier(
         model_name=pretrained_model_name,
-        num_classes=len(labels_json),    # CIFAR-10
+        num_classes=len(labels_json),
         lr=3e-4,
         hidden_dim=512,
     )
@@ -590,17 +631,18 @@ if __name__ == "__main__":
     
     print("Finalizing TFLite model output...")
     tf_model_path = tf_conversion_result.get('tf_model')
-    tf_to_tflite_result = tf_to_tflite(tf_model_path, os.path.join(model_folder, "model.tflite"), data_module.representative_dataloader())
+    representative_loader = data_module.representative_dataloader()
+    representative_samples = build_representative_samples(representative_loader)
+    tf_to_tflite_result = tf_to_tflite(
+        tf_model_path,
+        os.path.join(model_folder, "model.tflite"),
+        representative_samples,
+        converter_python
+    )
     if not tf_to_tflite_result['success']:
         print(f"Error: TF to TFLite conversion failed: {tf_to_tflite_result['error']}")
         sys.exit(1)
-    # tflite_conversion_result = finalize_tflite_output(tf_model_path, model_folder, onnx_model_path)
-    # if not tflite_conversion_result['success']:
-    #     print(f"Error: TFLite output finalization failed: {tflite_conversion_result['error']}")
-    #     sys.exit(1)
+
     print("TFLite model conversion completed successfully")
 
     print("Number of classes: ", len(labels_json))
-    
-    # tflite_model_path = tflite_conversion_result.get('tflite_model')
-    # print(f"TFLite model path: {tflite_model_path}")

--- a/pareidolia-desktop/py/pt_train_model.py
+++ b/pareidolia-desktop/py/pt_train_model.py
@@ -226,6 +226,67 @@ def verify_onnx_integrity(onnx_model_path):
         print(f"ONNX model integrity check failed: {str(e)}")
         return False
     
+def rep_test(loader):
+    tf, _, _, _ = import_tensorflow_keras()
+    # mean, std = compute_mean_std_welford_fast_test(loader)
+    # print("Calculated mean:", mean)
+    # print("Calculated std:", std)
+    MEAN = tf.constant([0.485, 0.456, 0.406], dtype=tf.float32)
+    STD  = tf.constant([0.229, 0.224, 0.225], dtype=tf.float32)
+
+    for idx, (image, _) in enumerate(loader):
+        # image is [batch, 3, 224, 224] from PyTorch DataLoader
+        # Process each image in the batch
+        for i in range(image.shape[0]):
+            img = image[i]  # [3, 224, 224]
+            img = tf.convert_to_tensor(img.permute(1, 2, 0).numpy())  # → [224, 224, 3]
+            img = tf.image.resize(img, [256, 256])                     # resize to 256x256
+            img = tf.image.resize_with_crop_or_pad(img, 224, 224)     # center crop to 224x224
+            img = tf.cast(img, tf.float32) 
+            # / 255.0                    # normalize [0, 255] → [0, 1]
+            img = (img - MEAN) / STD                                  # apply ImageNet mean/std
+            img = tf.expand_dims(img, axis=0)                         # add batch dim [1, 224, 224, 3]
+            yield [img]
+
+def compute_mean_std_welford_fast_test(loader, image_size=256, crop_size=224):
+    """Vectorized Welford — updates per image batch of pixels, not per pixel."""
+    tf, _, _, _ = import_tensorflow_keras()
+
+    n     = 0
+    mean  = np.zeros(3, dtype=np.float64)
+    M2    = np.zeros(3, dtype=np.float64)
+
+    for i, (image, _) in enumerate(loader):
+        img = tf.convert_to_tensor(image[0].permute(1, 2, 0).numpy())  # → [H, W, C]
+        img = tf.image.resize(img, [image_size, image_size], method=tf.image.ResizeMethod.BICUBIC)
+        img = tf.image.resize_with_crop_or_pad(img, crop_size, crop_size)
+        img = tf.cast(img, tf.float32) 
+        # / 255.0
+
+        pixels = tf.reshape(img, [-1, 3]).numpy()    # [50176, 3]
+        batch_n = len(pixels)
+
+        # parallel Welford merge (Chan's parallel algorithm)
+        batch_mean = pixels.mean(axis=0)
+        batch_M2   = pixels.var(axis=0) * batch_n
+
+        delta  = batch_mean - mean # delta between batch mean and current mean
+        total  = n + batch_n       # total count of pixels after adding this batch
+
+        mean  += delta * (batch_n / total) # adjust the running mean based on the current batch
+
+        # squared difference between means measures how far apart the means are from each other
+        # variance is based on the squared differences from the mean
+        # 
+        M2    += batch_M2 + delta**2 * (n * batch_n / total) # running total of squared differences from the mean, adjusted for the new batch
+        n      = total # update total count of pixels
+
+    std = np.sqrt(M2 / n) # variance is M2/n, std is sqrt of variance; this is std of the entire dataset after processing all batches
+
+    return mean.astype(np.float32), std.astype(np.float32)
+
+
+
 def compute_mean_std_welford_fast(image_paths, image_size=256, crop_size=224):
     """Vectorized Welford — updates per image batch of pixels, not per pixel."""
     tf, _, _, _ = import_tensorflow_keras()
@@ -328,7 +389,7 @@ def convert_onnx_to_tf(onnx_model_path, tf_model_path, converter_python):
 def collect_generated_tflite(tf_model_path, onnx_model_path):
     base_name = os.path.splitext(os.path.basename(onnx_model_path))[0]
     preferred_files = [
-        os.path.join(tf_model_path, f"{base_name}_float32.tflite"),
+        os.path.join(tf_model_path, f"{base_name}_float32.tflite"), 
         os.path.join(tf_model_path, f"{base_name}_float16.tflite"),
         os.path.join(tf_model_path, f"{base_name}.tflite"),
     ]
@@ -360,6 +421,49 @@ def finalize_tflite_output(tf_model_path, model_folder, onnx_model_path):
             'error': str(e)
         }
 
+def tf_to_tflite(tf_model_path, tflite_model_path, loader):
+    tf, _, _, _ = import_tensorflow_keras()
+
+    try:
+        converter = tf.lite.TFLiteConverter.from_saved_model(tf_model_path)
+        converter.optimizations = [tf.lite.Optimize.DEFAULT]
+        # converter.representative_dataset = representative_data_gen
+        converter.representative_dataset = lambda: rep_test(loader)
+        converter.target_spec.supported_ops = [
+            tf.lite.OpsSet.TFLITE_BUILTINS_INT8,
+            tf.lite.OpsSet.TFLITE_BUILTINS,
+        ]
+        converter.inference_input_type = tf.uint8
+        converter.inference_output_type = tf.float32
+        tflite_model = converter.convert()
+
+        with open(tflite_model_path, "wb") as f:
+            f.write(tflite_model)
+
+        print(f"TFLite model saved to: {tflite_model_path}")
+        return {
+            'success': True,
+            'tflite_model': tflite_model_path
+        }
+    except Exception as e:
+        print(f"Error converting TF to TFLite: {str(e)}")
+        return {
+            'success': False,
+            'error': str(e)
+        }
+class RepVGGWithPreprocess(pl.LightningModule):
+    def __init__(self, base_model):
+        super().__init__()
+        self.model = base_model
+        self.register_buffer('mean', torch.tensor([0.485, 0.456, 0.406]).view(1, 3, 1, 1))
+        self.register_buffer('std', torch.tensor([0.229, 0.224, 0.225]).view(1, 3, 1, 1))
+
+    def forward(self, x):
+        x = x / 255.0
+        x = (x - self.mean) / self.std
+        logits = self.model(x)
+        return torch.softmax(logits, dim=1)
+
 # Functions are declared above and used here
 if __name__ == "__main__":
     # Check for required arguments
@@ -376,13 +480,15 @@ if __name__ == "__main__":
     model_folder = sys.argv[2]
     epochs = int(sys.argv[3])
     pretrained_model_name = sys.argv[4]
+
+    labels_json = json.loads(labels_json_str)
     
     print(json.dumps(labels_json_str, indent=2))
 
     print(f"Model will be saved to folder: {model_folder}")
     print(f"Training for {epochs} epochs")
 
-    pl.seed_everything(42, workers=True)
+    pl.seed_everything(77, workers=True)
 
     data_module = ImageDataModule(
         data_dir="./data",
@@ -390,7 +496,7 @@ if __name__ == "__main__":
         img_size=224,
         num_workers=0,
         val_split=0.2,
-        seed=42,
+        seed=77,
         cifar10=False,
         labels_json=labels_json_str,
     )
@@ -398,7 +504,7 @@ if __name__ == "__main__":
     # Load and prepare images from the JSON label map
     model = RepVGGClassifier(
         model_name=pretrained_model_name,
-        num_classes=10,    # CIFAR-10
+        num_classes=len(labels_json),    # CIFAR-10
         lr=3e-4,
         hidden_dim=512,
     )
@@ -407,7 +513,7 @@ if __name__ == "__main__":
         monitor="val_acc",
         mode="max",
         save_top_k=1,
-        filename="repvgg-a2-cifar10-{epoch:02d}-{val_acc:.4f}",
+        filename="repvgg-{epoch:02d}-{val_acc:.4f}",
     )
 
     early_stop_cb = EarlyStopping(
@@ -418,7 +524,7 @@ if __name__ == "__main__":
 
     lr_monitor_cb = LearningRateMonitor(logging_interval="epoch")
 
-    csv_logger = CSVLogger("logs", name="repvgg_a2_cifar10")
+    csv_logger = CSVLogger("logs", name="repvgg")
 
     trainer = pl.Trainer(
         max_epochs=epochs,
@@ -437,9 +543,16 @@ if __name__ == "__main__":
     trainer.fit(model, datamodule=data_module)
 
     model.eval()
+    # Patch forward for export
+    # original_forward = model.forward
+    # model.forward = lambda x: torch.softmax(original_forward(x), dim=1)
+    # mean, std = compute_mean_std_welford_fast_test(data_module.representative_dataloader())
+    wrapped_model = RepVGGWithPreprocess(model)
+    wrapped_model.to(trainer.strategy.root_device)
+
 
     print("Converting model to ONNX format...")
-    onnx_conversion_result = convert_pt_to_onnx(model, model_folder)
+    onnx_conversion_result = convert_pt_to_onnx(wrapped_model, model_folder)
     if not onnx_conversion_result['success']:
         print(f"Error: ONNX conversion failed: {onnx_conversion_result['error']}")
         sys.exit(1)
@@ -477,11 +590,17 @@ if __name__ == "__main__":
     
     print("Finalizing TFLite model output...")
     tf_model_path = tf_conversion_result.get('tf_model')
-    tflite_conversion_result = finalize_tflite_output(tf_model_path, model_folder, onnx_model_path)
-    if not tflite_conversion_result['success']:
-        print(f"Error: TFLite output finalization failed: {tflite_conversion_result['error']}")
+    tf_to_tflite_result = tf_to_tflite(tf_model_path, os.path.join(model_folder, "model.tflite"), data_module.representative_dataloader())
+    if not tf_to_tflite_result['success']:
+        print(f"Error: TF to TFLite conversion failed: {tf_to_tflite_result['error']}")
         sys.exit(1)
+    # tflite_conversion_result = finalize_tflite_output(tf_model_path, model_folder, onnx_model_path)
+    # if not tflite_conversion_result['success']:
+    #     print(f"Error: TFLite output finalization failed: {tflite_conversion_result['error']}")
+    #     sys.exit(1)
     print("TFLite model conversion completed successfully")
+
+    print("Number of classes: ", len(labels_json))
     
-    tflite_model_path = tflite_conversion_result.get('tflite_model')
-    print(f"TFLite model path: {tflite_model_path}")
+    # tflite_model_path = tflite_conversion_result.get('tflite_model')
+    # print(f"TFLite model path: {tflite_model_path}")

--- a/pareidolia-desktop/py/pt_train_model.py
+++ b/pareidolia-desktop/py/pt_train_model.py
@@ -229,10 +229,14 @@ def verify_onnx_integrity(onnx_model_path):
         return False
     
 def rep_test(loader):
+    """
+    Deprecated: this function was an initial test for building representative samples directly as a generator, 
+    but was found to cause TF/PyTorch runtime lock contention issues on macOS when both frameworks are used in 
+    the same process. The current implementation materializes the representative samples into a numpy array in a 
+    separate function, and on macOS the TFLite conversion is done in a separate subprocess to avoid these issues.
+    """
     tf, _, _, _ = import_tensorflow_keras()
-    # mean, std = compute_mean_std_welford_fast_test(loader)
-    # print("Calculated mean:", mean)
-    # print("Calculated std:", std)
+
     MEAN = tf.constant([0.485, 0.456, 0.406], dtype=tf.float32)
     STD  = tf.constant([0.229, 0.224, 0.225], dtype=tf.float32)
 
@@ -255,6 +259,9 @@ def build_representative_samples(loader, max_samples=REPRESENTATIVE_SAMPLE_COUNT
     Materializes representative calibration samples as NHWC float32 arrays.
     This keeps TF conversion in a clean subprocess and avoids TF/PyTorch
     runtime lock contention inside one process on macOS.
+
+    Basically takes images from a DataLoader and applies the same resizing, cropping, and normalization that the model expects,
+    and puts them into a numpy array.
     """
     mean = np.array([0.485, 0.456, 0.406], dtype=np.float32)
     std = np.array([0.229, 0.224, 0.225], dtype=np.float32)
@@ -279,7 +286,12 @@ def build_representative_samples(loader, max_samples=REPRESENTATIVE_SAMPLE_COUNT
     return np.stack(samples, axis=0).astype(np.float32)
 
 def compute_mean_std_welford_fast_test(loader, image_size=256, crop_size=224):
-    """Vectorized Welford — updates per image batch of pixels, not per pixel."""
+    """
+    Deprecated: this function was the initial welford's algorithm implementation for calculating mean and std for the representative dataset,
+    but will be used in the future for a user if they build their own model with their own dataset.
+
+    Vectorized Welford — updates per image batch of pixels, not per pixel. Used a dataloader instead of file paths. Creates threading issues on MacOS.
+    """
     tf, _, _, _ = import_tensorflow_keras()
 
     n     = 0
@@ -318,7 +330,12 @@ def compute_mean_std_welford_fast_test(loader, image_size=256, crop_size=224):
 
 
 def compute_mean_std_welford_fast(image_paths, image_size=256, crop_size=224):
-    """Vectorized Welford — updates per image batch of pixels, not per pixel."""
+    """
+    Deprecated: this function was the initial welford's algorithm implementation for calculating mean and std for the representative dataset,
+    but will be used in the future for a user if they build their own model with their own dataset.
+
+    Vectorized Welford — updates per image batch of pixels, not per pixel.
+    """
     tf, _, _, _ = import_tensorflow_keras()
 
     n     = 0
@@ -416,6 +433,12 @@ def convert_onnx_to_tf(onnx_model_path, tf_model_path, converter_python):
         }
 
 def tf_to_tflite(tf_model_path, tflite_model_path, representative_samples, converter_python):
+    """
+    Checks for the current OS and creates a subprocess to run the TF to TFLite conversion with the representative dataset, 
+    passing the representative samples via a temporary file on disk for macOS to avoid TF/PyTorch runtime lock contention issues. 
+    
+    On non-macOS platforms, it runs the conversion directly in-process since these issues are not present.
+    """
     representative_path = None
     try:
         os.makedirs(os.path.dirname(tflite_model_path), exist_ok=True)
@@ -453,7 +476,7 @@ def tf_to_tflite(tf_model_path, tflite_model_path, representative_samples, conve
                 ],
                 env=env,
             )
-        else:
+        else: # Windows route and fallback for non-macOS
             tf, _, _, _ = import_tensorflow_keras()
 
             def representative_dataset():
@@ -493,6 +516,11 @@ def tf_to_tflite(tf_model_path, tflite_model_path, representative_samples, conve
                 print(f"Could not delete temporary representative data file: {representative_path}")
 
 class RepVGGWithPreprocess(pl.LightningModule):
+    """
+    Model wrapper that applies the necessary preprocessing (resizing, cropping, normalization) before forwarding to the base model.
+    This allows the ONNX export to include the preprocessing steps, ensuring the exported model can be used directly without needing 
+    to replicate preprocessing separately in the TFLite conversion or in the final application.
+    """
     def __init__(self, base_model):
         super().__init__()
         self.model = base_model
@@ -584,13 +612,10 @@ if __name__ == "__main__":
     trainer.fit(model, datamodule=data_module)
 
     model.eval()
-    # Patch forward for export
-    # original_forward = model.forward
-    # model.forward = lambda x: torch.softmax(original_forward(x), dim=1)
-    # mean, std = compute_mean_std_welford_fast_test(data_module.representative_dataloader())
+
+    # wrap model to allow for preproccessing in onnx export
     wrapped_model = RepVGGWithPreprocess(model)
     wrapped_model.to(trainer.strategy.root_device)
-
 
     print("Converting model to ONNX format...")
     onnx_conversion_result = convert_pt_to_onnx(wrapped_model, model_folder)
@@ -633,6 +658,7 @@ if __name__ == "__main__":
     tf_model_path = tf_conversion_result.get('tf_model')
     representative_loader = data_module.representative_dataloader()
     representative_samples = build_representative_samples(representative_loader)
+
     tf_to_tflite_result = tf_to_tflite(
         tf_model_path,
         os.path.join(model_folder, "model.tflite"),

--- a/pareidolia-desktop/py/tflite_convert_worker.py
+++ b/pareidolia-desktop/py/tflite_convert_worker.py
@@ -1,0 +1,57 @@
+import argparse
+import os
+import sys
+import numpy as np
+
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "1")
+if sys.platform == "darwin":
+    os.environ.setdefault("TF_NUM_INTEROP_THREADS", "1")
+    os.environ.setdefault("TF_NUM_INTRAOP_THREADS", "1")
+    os.environ.setdefault("OMP_NUM_THREADS", "1")
+
+import tensorflow as tf
+
+
+def representative_dataset(samples):
+    for sample in samples:
+        yield [np.expand_dims(sample.astype(np.float32), axis=0)]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert TF SavedModel to TFLite with quantization.")
+    parser.add_argument("--saved-model", required=True, help="Path to TensorFlow SavedModel directory.")
+    parser.add_argument("--output", required=True, help="Path to output .tflite file.")
+    parser.add_argument("--rep-data", required=True, help="Path to representative .npy samples (NHWC float32).")
+    args = parser.parse_args()
+
+    samples = np.load(args.rep_data).astype(np.float32)
+    if samples.ndim != 4:
+        raise ValueError(f"Representative data must be rank-4 NHWC, got shape {samples.shape}")
+
+    if sys.platform == "darwin":
+        try:
+            tf.config.threading.set_inter_op_parallelism_threads(int(os.environ.get("TF_NUM_INTEROP_THREADS", "1")))
+            tf.config.threading.set_intra_op_parallelism_threads(int(os.environ.get("TF_NUM_INTRAOP_THREADS", "1")))
+        except Exception:
+            pass
+
+    converter = tf.lite.TFLiteConverter.from_saved_model(args.saved_model)
+    converter.optimizations = [tf.lite.Optimize.DEFAULT]
+    converter.representative_dataset = lambda: representative_dataset(samples)
+    converter.target_spec.supported_ops = [
+        tf.lite.OpsSet.TFLITE_BUILTINS_INT8,
+        tf.lite.OpsSet.TFLITE_BUILTINS,
+    ]
+    converter.inference_input_type = tf.uint8
+    converter.inference_output_type = tf.float32
+
+    tflite_model = converter.convert()
+    os.makedirs(os.path.dirname(args.output), exist_ok=True)
+    with open(args.output, "wb") as f:
+        f.write(tflite_model)
+
+    print(f"TFLite model written: {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The mutex issue that was on MacOS was due to conflicts of threads not releasing their mutex lock to allow for other subprocesses to execute at the same time. The fix for this was to separate the Tensorflow to TFLite conversion to a separated subprocess in another python file using a different conversion virtual environment. From now on, conversions on MacOS requires some space (~77 MB) for a .npy file to be created which will hold the representative dataset data to be saved in between processes on MacOS, and will be promptly deleted whether or not conversion is successful or not. This fix has been isolated to MacOS and Windows has been tested to still work as intended.

Addresses issue #59 and contributes towards issue #54

**Time Spent:** 2 Days