### PR TITLE
Pytorch Scratch Path

### DIFF
--- a/pareidolia-desktop/package-lock.json
+++ b/pareidolia-desktop/package-lock.json
@@ -568,6 +568,7 @@
       "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -1740,6 +1741,7 @@
       "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^3.0.1",
         "@inquirer/confirm": "^4.0.1",
@@ -2910,6 +2912,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2976,6 +2979,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3257,6 +3261,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4722,17 +4727,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/end-of-stream": {
@@ -8792,6 +8786,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9715,6 +9710,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9728,6 +9724,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9834,6 +9831,7 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/pareidolia-desktop/py/image_data_module.py
+++ b/pareidolia-desktop/py/image_data_module.py
@@ -10,6 +10,9 @@ from torch.utils.data import DataLoader, Dataset, random_split
 from torchvision import transforms, datasets
 from numpy_image_dataset import NumpyImageDataset
 
+IMAGENET_MEAN = [0.485, 0.456, 0.406]
+IMAGENET_STD = [0.229, 0.224, 0.225]
+
 class NumpyImageDataset(Dataset):
     """
     Author: Armando Vega
@@ -76,6 +79,8 @@ class ImageDataModule(pl.LightningDataModule):
         cifar10=False, 
         labels_json=None, # this is a string btw
         test_split=0.1,   # the fraction of the dataset to use for testing when loading from a directory or JSON; ignored if cifar10=True since CIFAR-10 has a predefined train/test split
+        normalization_mean=None,
+        normalization_std=None,
     ):
         super().__init__()
         self.data_dir = data_dir
@@ -90,6 +95,8 @@ class ImageDataModule(pl.LightningDataModule):
         self._json_dataset_cache = None
         self._split_indices_cache = None
         self.resize_size = 256
+        self.normalization_mean = list(normalization_mean or IMAGENET_MEAN)
+        self.normalization_std = list(normalization_std or IMAGENET_STD)
 
         if not (0 <= self.val_split < 1):
             raise ValueError(f"val_split must be in [0, 1), got {self.val_split}")
@@ -100,27 +107,43 @@ class ImageDataModule(pl.LightningDataModule):
                 f"val_split + test_split must be < 1, got {self.val_split + self.test_split}"
             )
 
+        self._build_transforms()
+
+    def _build_transforms(self):
+        normalize = transforms.Normalize(mean=self.normalization_mean, std=self.normalization_std)
+
         self.train_transform = transforms.Compose([ # training preprocessing: resize up, augment, then crop to model size
             transforms.Resize((self.resize_size, self.resize_size)),
             transforms.RandomHorizontalFlip(p=0.5),
             transforms.RandomRotation(degrees=15),
             transforms.ColorJitter(brightness=0.2, contrast=0.2),
-            transforms.RandomCrop(img_size),
+            transforms.RandomCrop(self.img_size),
             transforms.ToTensor(),
-            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+            normalize,
         ])
 
         self.eval_transform = transforms.Compose([ # evaluation preprocessing matches exported model preprocessing
             transforms.Resize((self.resize_size, self.resize_size)),
-            transforms.CenterCrop(img_size),
+            transforms.CenterCrop(self.img_size),
             transforms.ToTensor(),
-            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+            normalize,
         ])
 
         self.rep_transform = transforms.Compose([ # representative data should match the wrapped TF/TFLite model's raw input domain
             transforms.Resize((self.resize_size, self.resize_size)),
             transforms.PILToTensor(),
         ])
+
+        self.stats_transform = transforms.Compose([
+            transforms.Resize((self.resize_size, self.resize_size)),
+            transforms.CenterCrop(self.img_size),
+            transforms.ToTensor(),
+        ])
+
+    def set_normalization(self, mean, std):
+        self.normalization_mean = [float(value) for value in mean]
+        self.normalization_std = [max(float(value), 1e-6) for value in std]
+        self._build_transforms()
 
     def load_images_from_json(self, labels_json):
         """Load images from a JSON mapping of label names to arrays of folder paths."""
@@ -336,6 +359,34 @@ class ImageDataModule(pl.LightningDataModule):
     def representative_dataloader(self):
         return DataLoader(
             self.rep_ds,
+            batch_size=self.batch_size,
+            shuffle=False,
+            num_workers=self.num_workers,
+            pin_memory=torch.cuda.is_available(),
+            persistent_workers=self.num_workers > 0,
+        )
+
+    def normalization_stats_dataloader(self):
+        if self.labels_json is not None:
+            images, labels, _, _ = self._get_json_dataset()
+            train_indices, _, _ = self._get_split_indices(len(images))
+            stats_base = NumpyImageDataset(images, labels, transform=self.stats_transform)
+            stats_ds = torch.utils.data.Subset(stats_base, train_indices)
+        elif self.cifar10:
+            stats_base = datasets.CIFAR10(root=self.data_dir, train=True, transform=self.stats_transform, download=False)
+            n_total = len(stats_base)
+            n_val = int(self.val_split * n_total)
+            n_train = n_total - n_val
+            generator = torch.Generator().manual_seed(self.seed)
+            train_indices = torch.randperm(n_total, generator=generator).tolist()[:n_train]
+            stats_ds = torch.utils.data.Subset(stats_base, train_indices)
+        else:
+            stats_base = datasets.ImageFolder(self.data_dir, transform=self.stats_transform)
+            train_indices, _, _ = self._get_split_indices(len(stats_base))
+            stats_ds = torch.utils.data.Subset(stats_base, train_indices)
+
+        return DataLoader(
+            stats_ds,
             batch_size=self.batch_size,
             shuffle=False,
             num_workers=self.num_workers,

--- a/pareidolia-desktop/py/pt_model.py
+++ b/pareidolia-desktop/py/pt_model.py
@@ -5,6 +5,42 @@ import timm
 import pytorch_lightning as pl
 from torchmetrics import Accuracy
 
+
+def _activation_from_name(name):
+    activation_name = str(name or "relu").lower()
+    activations = {
+        "relu": nn.ReLU,
+        "sigmoid": nn.Sigmoid,
+        "tanh": nn.Tanh,
+        "leaky_relu": nn.LeakyReLU,
+        "leakyrelu": nn.LeakyReLU,
+        "gelu": nn.GELU,
+        "silu": nn.SiLU,
+        "swish": nn.SiLU,
+        "none": None,
+        "linear": None,
+    }
+    if activation_name not in activations:
+        raise ValueError(f"Unsupported activation for PyTorch scratch model: {name}")
+
+    activation_cls = activations[activation_name]
+    return activation_cls() if activation_cls is not None else None
+
+
+def _as_int(parameters, key, default):
+    return int(parameters.get(key, default))
+
+
+def _as_float(parameters, key, default):
+    return float(parameters.get(key, default))
+
+
+def _same_padding(kernel_size):
+    if isinstance(kernel_size, tuple):
+        return tuple(k // 2 for k in kernel_size)
+    return kernel_size // 2
+
+
 class RepVGGClassifier(pl.LightningModule):
     """
     Author: Armando Vega
@@ -74,6 +110,145 @@ class RepVGGClassifier(pl.LightningModule):
         self.log("test_acc", acc, on_step=False, on_epoch=True, prog_bar=True)
         return loss
     
+    def predict_step(self, batch, batch_idx, dataloader_idx=0):
+        x = batch[0] if isinstance(batch, (tuple, list)) else batch
+        logits = self(x)
+        probs = torch.softmax(logits, dim=1)
+        preds = torch.argmax(probs, dim=1)
+        return {"preds": preds, "probs": probs}
+
+    def configure_optimizers(self):
+        return torch.optim.Adam(self.parameters(), lr=self.hparams.lr)
+
+
+class ScratchCNNClassifier(pl.LightningModule):
+    """
+    A PyTorch Lightning module that builds a CNN from the same layer JSON shape
+    used by the TensorFlow scratch model builder.
+    """
+    def __init__(self, layers_json=None, num_classes=10, lr=1e-3, input_channels=3):
+        super().__init__()
+        self.save_hyperparameters()
+
+        self.model = self._build_model(layers_json or [], num_classes, input_channels)
+
+        self.train_acc = Accuracy(task="multiclass", num_classes=num_classes)
+        self.val_acc = Accuracy(task="multiclass", num_classes=num_classes)
+        self.test_acc = Accuracy(task="multiclass", num_classes=num_classes)
+
+    def _build_model(self, layers_json, num_classes, input_channels):
+        modules = []
+        in_channels = input_channels
+        has_flattened = False
+        last_linear_features = None
+
+        for layer_data in layers_json:
+            layer_type = layer_data.get("type")
+            parameters = layer_data.get("parameters", {}) or {}
+
+            if layer_type in ("RandomFlip", "RandomRotation", "RandomZoom", "RandomContrast"):
+                continue
+
+            if layer_type == "Conv2D":
+                filters = _as_int(parameters, "units", parameters.get("filters", 32))
+                kernel_size = _as_int(parameters, "kernel_size", 3)
+                stride = _as_int(parameters, "stride", 1)
+                padding_param = parameters.get("padding", "same")
+                padding = _same_padding(kernel_size) if padding_param == "same" else int(padding_param)
+
+                modules.append(nn.Conv2d(in_channels, filters, kernel_size=kernel_size, stride=stride, padding=padding))
+                activation = _activation_from_name(parameters.get("activation", "relu"))
+                if activation is not None:
+                    modules.append(activation)
+
+                in_channels = filters
+                has_flattened = False
+                last_linear_features = None
+            elif layer_type == "MaxPooling2D":
+                pool_size = _as_int(parameters, "pool_size", 2)
+                modules.append(nn.MaxPool2d(kernel_size=pool_size))
+                has_flattened = False
+
+            elif layer_type == "AveragePooling2D":
+                pool_size = _as_int(parameters, "pool_size", 2)
+                modules.append(nn.AvgPool2d(kernel_size=pool_size))
+                has_flattened = False
+
+            elif layer_type == "GlobalAveragePooling2D":
+                modules.append(nn.AdaptiveAvgPool2d((1, 1)))
+                modules.append(nn.Flatten())
+                has_flattened = True
+                last_linear_features = in_channels
+
+            elif layer_type == "Flatten":
+                modules.append(nn.Flatten())
+                has_flattened = True
+                last_linear_features = None
+                
+            elif layer_type == "Dense":
+                if not has_flattened:
+                    modules.append(nn.Flatten())
+                    has_flattened = True
+
+                units = _as_int(parameters, "units", 128)
+                if last_linear_features is None:
+                    modules.append(nn.LazyLinear(units))
+                else:
+                    modules.append(nn.Linear(last_linear_features, units))
+
+                activation = _activation_from_name(parameters.get("activation", "relu"))
+                if activation is not None:
+                    modules.append(activation)
+
+                last_linear_features = units
+            elif layer_type == "Dropout":
+                modules.append(nn.Dropout(_as_float(parameters, "rate", 0.2)))
+            else:
+                raise ValueError(f"Unsupported PyTorch scratch layer type: {layer_type}")
+
+        if not has_flattened:
+            modules.append(nn.Flatten())
+
+        if last_linear_features is None:
+            modules.append(nn.LazyLinear(num_classes))
+        else:
+            modules.append(nn.Linear(last_linear_features, num_classes))
+
+        return nn.Sequential(*modules)
+
+    def forward(self, x):
+        return self.model(x)
+
+    def training_step(self, batch, batch_idx):
+        x, y = batch
+        logits = self(x)
+        loss = nn.functional.cross_entropy(logits, y)
+        acc = self.train_acc(logits, y)
+
+        self.log("train_loss", loss, on_step=False, on_epoch=True, prog_bar=True)
+        self.log("train_acc", acc, on_step=False, on_epoch=True, prog_bar=True)
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        x, y = batch
+        logits = self(x)
+        loss = nn.functional.cross_entropy(logits, y)
+        acc = self.val_acc(logits, y)
+
+        self.log("val_loss", loss, on_step=False, on_epoch=True, prog_bar=True)
+        self.log("val_acc", acc, on_step=False, on_epoch=True, prog_bar=True)
+        return loss
+
+    def test_step(self, batch, batch_idx):
+        x, y = batch
+        logits = self(x)
+        loss = nn.functional.cross_entropy(logits, y)
+        acc = self.test_acc(logits, y)
+
+        self.log("test_loss", loss, on_step=False, on_epoch=True, prog_bar=True)
+        self.log("test_acc", acc, on_step=False, on_epoch=True, prog_bar=True)
+        return loss
+
     def predict_step(self, batch, batch_idx, dataloader_idx=0):
         x = batch[0] if isinstance(batch, (tuple, list)) else batch
         logits = self(x)

--- a/pareidolia-desktop/py/pt_train_model.py
+++ b/pareidolia-desktop/py/pt_train_model.py
@@ -52,8 +52,8 @@ import math
 import torch
 import torch.nn as nn
 from torchmetrics import Accuracy
-from pt_model import RepVGGClassifier
-from image_data_module import ImageDataModule
+from pt_model import RepVGGClassifier, ScratchCNNClassifier
+from image_data_module import ImageDataModule, IMAGENET_MEAN, IMAGENET_STD
 from epoch_history_printer import EpochHistoryPrinter
 from pathlib import Path
 import glob
@@ -69,6 +69,8 @@ IMG_CHANNELS = 3
 REPRESENTATIVE_SAMPLE_COUNT = 128
 # NUM_CLASSES is now determined dynamically from the labels JSON at runtime
 LEARNING_RATE = 0.001
+MODEL_TYPE_SCRATCH = "scratch"
+MODEL_TYPE_PRETRAINED = "pretrained"
 CONVERTER_VENV_NAME = "converter-venv-macos-tf219"
 CONVERTER_REQUIREMENTS = [
     "tensorflow==2.19.1",
@@ -82,6 +84,73 @@ CONVERTER_REQUIREMENTS = [
     "onnxruntime==1.24.4",
     "onnxsim==0.4.36",
 ]
+
+DEFAULT_SCRATCH_LAYERS = [
+    {"type": "Conv2D", "parameters": {"units": "16", "activation": "relu"}},
+    {"type": "MaxPooling2D", "parameters": {"pool_size": "2"}},
+    {"type": "Conv2D", "parameters": {"units": "32", "activation": "relu"}},
+    {"type": "MaxPooling2D", "parameters": {"pool_size": "2"}},
+    {"type": "Conv2D", "parameters": {"units": "64", "activation": "relu"}},
+    {"type": "MaxPooling2D", "parameters": {"pool_size": "2"}},
+    {"type": "Dropout", "parameters": {"rate": "0.2"}},
+    {"type": "Flatten", "parameters": {}},
+    {"type": "Dense", "parameters": {"units": "128", "activation": "relu"}},
+    {"type": "Dropout", "parameters": {"rate": "0.3"}},
+    {"type": "Dense", "parameters": {"units": "64", "activation": "relu"}},
+    {"type": "Dropout", "parameters": {"rate": "0.2"}},
+    {"type": "Dense", "parameters": {"units": "32", "activation": "relu"}},
+]
+
+
+def parse_selected_layers(layers_arg):
+    """Parse the incoming layers JSON into a normalized list of layer dictionaries."""
+    def validate_layers(layer_items):
+        if not isinstance(layer_items, list):
+            raise ValueError("layers must be a JSON array")
+
+        normalized_layers = []
+        for index, layer_item in enumerate(layer_items):
+            if not isinstance(layer_item, dict):
+                raise ValueError(f"layer at index {index} must be an object")
+
+            layer_type = layer_item.get("type")
+            parameters = layer_item.get("parameters", {})
+
+            if not isinstance(layer_type, str) or not layer_type.strip():
+                raise ValueError(f"layer at index {index} is missing a valid 'type'")
+
+            if parameters is None:
+                parameters = {}
+            elif not isinstance(parameters, dict):
+                raise ValueError(f"layer at index {index} has invalid 'parameters'; expected an object")
+
+            normalized_layers.append({
+                "type": layer_type,
+                "parameters": parameters
+            })
+
+        return normalized_layers
+
+    if layers_arg is None:
+        return []
+
+    if isinstance(layers_arg, list):
+        return validate_layers(layers_arg)
+
+    if isinstance(layers_arg, str):
+        layers_arg = layers_arg.strip()
+        if not layers_arg:
+            return []
+
+        parsed_layers = json.loads(layers_arg)
+        if isinstance(parsed_layers, list):
+            return validate_layers(parsed_layers)
+        if isinstance(parsed_layers, dict):
+            if "layers" not in parsed_layers:
+                raise ValueError("layers object must contain a 'layers' array")
+            return validate_layers(parsed_layers["layers"])
+
+    raise ValueError("layers argument must be a JSON array or an object containing a 'layers' array")
 
 
 def delete_existing_checkpoints(model_folder):
@@ -392,6 +461,41 @@ def build_representative_samples(loader, max_samples=REPRESENTATIVE_SAMPLE_COUNT
 
     return np.stack(samples, axis=0).astype(np.float32)
 
+
+@torch.no_grad()
+def compute_mean_std_welford_from_loader(loader):
+    """
+    Calculates channel mean/std from a PyTorch dataloader using a vectorized
+    Welford/Chan merge. The loader should yield unnormalized images.
+    """
+    n = 0
+    mean = torch.zeros(3, dtype=torch.float64)
+    M2 = torch.zeros(3, dtype=torch.float64)
+
+    for images, _ in loader:
+        images = images.detach().cpu().to(torch.float64)
+        if images.max() > 2.0:
+            images = images / 255.0
+
+        pixels = images.permute(0, 2, 3, 1).reshape(-1, 3)
+        batch_n = pixels.shape[0]
+        batch_mean = pixels.mean(dim=0)
+        batch_M2 = pixels.var(dim=0, unbiased=False) * batch_n
+
+        delta = batch_mean - mean
+        total = n + batch_n
+
+        mean += delta * (batch_n / total)
+        M2 += batch_M2 + delta.pow(2) * (n * batch_n / total)
+        n = total
+
+    if n == 0:
+        raise RuntimeError("Cannot calculate normalization stats from an empty dataloader.")
+
+    std = torch.sqrt(M2 / n).clamp_min(1e-6)
+    return mean.float().tolist(), std.float().tolist()
+
+
 def compute_mean_std_welford_fast_test(loader, image_size=256, crop_size=224):
     """
     Deprecated: this function was the initial welford's algorithm implementation for calculating mean and std for the representative dataset,
@@ -648,11 +752,11 @@ class RepVGGWithPreprocess(pl.LightningModule):
     The exported model expects RGB images that have already been center-cropped
     to 224x224 and are provided as raw 0..255 pixel values in NCHW layout.
     """
-    def __init__(self, base_model):
+    def __init__(self, base_model, mean=None, std=None):
         super().__init__()
         self.model = base_model
-        self.register_buffer('mean', torch.tensor([0.485, 0.456, 0.406]).view(1, 3, 1, 1))
-        self.register_buffer('std', torch.tensor([0.229, 0.224, 0.225]).view(1, 3, 1, 1))
+        self.register_buffer('mean', torch.tensor(mean or IMAGENET_MEAN).view(1, 3, 1, 1))
+        self.register_buffer('std', torch.tensor(std or IMAGENET_STD).view(1, 3, 1, 1))
 
     def forward(self, x):
         x = x / 255.0
@@ -663,19 +767,31 @@ class RepVGGWithPreprocess(pl.LightningModule):
 # Functions are declared above and used here
 if __name__ == "__main__":
     # Check for required arguments
-    # Usage: python pt_train_model.py <labels_json> <model_path> <epochs> <pretrained_model_name>
+    # Usage:
+    #   Legacy pretrained:
+    #     python pt_train_model.py <labels_json> <model_path> <epochs> <pretrained_model_name>
+    #   Current:
+    #     python pt_train_model.py <labels_json> <model_path> <epochs> <project_type> <pretrained_model_name> <layers_json>
     #   labels_json - JSON string mapping label names to arrays of folder paths
     #                 e.g. '{"Apple": ["/path/to/apples"], "Orange": ["/path/a", "/path/b"]}'
     if len(sys.argv) < 5:
         print("Error: Missing required arguments")
-        print('Usage: python pt_train_model.py <labels_json> <model_path> <epochs> <pretrained_model_name>')
+        print('Usage: python pt_train_model.py <labels_json> <model_path> <epochs> <project_type|pretrained_model_name> [pretrained_model_name] [layers_json]')
         sys.exit(1)
     
     # Get command line arguments
     labels_json_str = sys.argv[1]
     model_folder = sys.argv[2]
     epochs = int(sys.argv[3])
-    pretrained_model_name = sys.argv[4]
+    arg4 = sys.argv[4]
+    if arg4 in (MODEL_TYPE_SCRATCH, MODEL_TYPE_PRETRAINED):
+        project_type = arg4
+        pretrained_model_name = sys.argv[5] if len(sys.argv) > 5 else "repvgg_a2"
+        selected_layers = parse_selected_layers(sys.argv[6] if len(sys.argv) > 6 else None)
+    else:
+        project_type = MODEL_TYPE_PRETRAINED
+        pretrained_model_name = arg4
+        selected_layers = []
 
     labels_json = json.loads(labels_json_str)
     
@@ -683,9 +799,12 @@ if __name__ == "__main__":
 
     print(f"Model will be saved to folder: {model_folder}")
     print(f"Training for {epochs} epochs")
+    print(f"PyTorch project type: {project_type}")
 
     pl.seed_everything(42, workers=True)
 
+    normalization_mean = IMAGENET_MEAN
+    normalization_std = IMAGENET_STD
     data_module = ImageDataModule(
         data_dir="./data",
         batch_size=64,
@@ -695,15 +814,40 @@ if __name__ == "__main__":
         seed=42,
         cifar10=False,
         labels_json=labels_json_str,
+        normalization_mean=normalization_mean,
+        normalization_std=normalization_std,
     )
-    
-    # Load and prepare images from the JSON label map
-    model = RepVGGClassifier(
-        model_name=pretrained_model_name,
-        num_classes=len(labels_json),
-        lr=3e-4,
-        hidden_dim=512,
-    )
+
+    if project_type == MODEL_TYPE_SCRATCH:
+        selected_layers = selected_layers or DEFAULT_SCRATCH_LAYERS
+
+        print(f"Building PyTorch scratch model with {len(selected_layers)} user-configured layers.")
+        print("Calculating scratch normalization mean/std from the training split...")
+
+        stats_loader = data_module.normalization_stats_dataloader()
+        normalization_mean, normalization_std = compute_mean_std_welford_from_loader(stats_loader)
+        data_module.set_normalization(normalization_mean, normalization_std)
+
+        print(f"Calculated normalization mean: {normalization_mean}")
+        print(f"Calculated normalization std: {normalization_std}")
+
+        model = ScratchCNNClassifier(
+            layers_json=selected_layers,
+            num_classes=len(labels_json),
+            lr=LEARNING_RATE,
+        )
+        checkpoint_prefix = "scratch"
+        model_class = ScratchCNNClassifier
+    else:
+        print(f"Building PyTorch pretrained model with timm backbone: {pretrained_model_name}")
+        model = RepVGGClassifier(
+            model_name=pretrained_model_name,
+            num_classes=len(labels_json),
+            lr=3e-4,
+            hidden_dim=512,
+        )
+        checkpoint_prefix = "repvgg"
+        model_class = RepVGGClassifier
 
     delete_existing_checkpoints(model_folder)
 
@@ -712,7 +856,7 @@ if __name__ == "__main__":
         mode="max",
         save_top_k=1,
         dirpath=model_folder,
-        filename="repvgg-{epoch:02d}-{val_acc:.4f}",
+        filename=f"{checkpoint_prefix}" + "-{epoch:02d}-{val_acc:.4f}",
     )
 
     early_stop_cb = EarlyStopping(
@@ -723,7 +867,7 @@ if __name__ == "__main__":
 
     lr_monitor_cb = LearningRateMonitor(logging_interval="epoch")
 
-    csv_logger = CSVLogger("logs", name="repvgg")
+    csv_logger = CSVLogger("logs", name=checkpoint_prefix)
 
     trainer = pl.Trainer(
         max_epochs=epochs,
@@ -744,14 +888,14 @@ if __name__ == "__main__":
     best_model_path = checkpoint_cb.best_model_path
     if best_model_path:
         print(f"Loading best checkpoint for export: {best_model_path}")
-        model = RepVGGClassifier.load_from_checkpoint(best_model_path)
+        model = model_class.load_from_checkpoint(best_model_path)
     else:
         print("No best checkpoint found; exporting the current in-memory model.")
 
     model.eval()
 
     # wrap model to allow for preproccessing in onnx export
-    wrapped_model = RepVGGWithPreprocess(model)
+    wrapped_model = RepVGGWithPreprocess(model, mean=normalization_mean, std=normalization_std)
 
     print("Converting model to ONNX format...")
     onnx_conversion_result = convert_pt_to_onnx(wrapped_model, model_folder)

--- a/pareidolia-desktop/src/main.js
+++ b/pareidolia-desktop/src/main.js
@@ -783,7 +783,9 @@ ipcMain.handle('execute-train', async (event, params) => {
         JSON.stringify(labelsJson),
         modelFolderPath,
         epochs.toString(),
-        'repvgg_a2'
+        normalizedProjectType,
+        'repvgg_a2',
+        JSON.stringify(Array.isArray(layers) ? layers : [])
       ];
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
### MERGE TENSORUPDATE PR FIRST

Created a path in the Pytorch training pipeline to use the layers chosen by the user. The preprocessing mismatch has been standardized to the DataLoader level for both the pretrained and from scratch path. ImageDataModule now supports both the from scratch and pretrained paths. Mean and std are calculated via welford's algorithm at the training pipeline level if the user is training from scratch. The existing Pytorch pipeline is still preserved.

Addresses issue #65, #69

**Time Spent:** 2 Days